### PR TITLE
Update home-result to show commit ID

### DIFF
--- a/src/main/resources/mustache/home-result.mustache
+++ b/src/main/resources/mustache/home-result.mustache
@@ -3,6 +3,15 @@
   {{environmentDescription}}<br>
   {{#uuid}}
     Run ID: <code>{{uuid}}</code><br>
+    {{#commitId}}
+      Commit:&nbsp;
+      {{#browseCommitUrl}}
+        <a href="{{browseCommitUrl}}"><code>{{commitId}}</code></a>
+      {{/browseCommitUrl}}
+      {{^browseCommitUrl}}
+        <code>{{commitId}}</code>
+      {{/browseCommitUrl}}
+    {{/commitId}}
     <a href="/results/{{uuid}}">details</a><br>
     {{#zipFileName}}
       <a href="https://www.techempower.com/benchmarks/#section=test&runid={{uuid}}">visualize</a><br>


### PR DESCRIPTION
This would update the main results page to show the commit under the Run ID. I was recently searching for a commit ID and had to click into the details of each run until I found it. This would just make that a little easier. It also doesn't expand the size of the rows.